### PR TITLE
Implemented MoeFutureTask for convinience

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,7 +1,5 @@
 module moe.maple.scheduler {
     exports moe.maple.scheduler;
-    exports moe.maple.scheduler.target;
-    exports moe.maple.scheduler.target.delay;
     exports moe.maple.scheduler.tasks;
     exports moe.maple.scheduler.tasks.delay;
     exports moe.maple.scheduler.tasks.tick;

--- a/src/main/java/moe/maple/scheduler/MoeBasicScheduler.java
+++ b/src/main/java/moe/maple/scheduler/MoeBasicScheduler.java
@@ -22,6 +22,7 @@
 
 package moe.maple.scheduler;
 
+import moe.maple.scheduler.tasks.MoeFutureTask;
 import moe.maple.scheduler.tasks.MoeTask;
 
 import java.util.Objects;
@@ -81,6 +82,9 @@ public final class MoeBasicScheduler implements MoeScheduler {
     @Override
     public void register(MoeTask task) {
         Objects.requireNonNull(task);
+        if(task instanceof MoeFutureTask) {
+            ((MoeFutureTask) task).registerScheduler(this);
+        }
         registry.add(task);
     }
 

--- a/src/main/java/moe/maple/scheduler/MoeBasicScheduler.java
+++ b/src/main/java/moe/maple/scheduler/MoeBasicScheduler.java
@@ -85,14 +85,14 @@ public final class MoeBasicScheduler implements MoeScheduler {
     }
 
     @Override
-    public void unregister(MoeTask task) {
+    public boolean unregister(MoeTask task) {
         Objects.requireNonNull(task);
-        registry.remove(task);
+        return registry.remove(task);
     }
 
     @Override
-    public void remove(Predicate<MoeTask> check) {
-        registry.removeIf(check);
+    public boolean remove(Predicate<MoeTask> check) {
+        return registry.removeIf(check);
     }
 
     @Override

--- a/src/main/java/moe/maple/scheduler/tasks/MoeFutureTask.java
+++ b/src/main/java/moe/maple/scheduler/tasks/MoeFutureTask.java
@@ -1,0 +1,12 @@
+package moe.maple.scheduler.tasks;
+
+import moe.maple.scheduler.MoeScheduler;
+
+public interface MoeFutureTask extends MoeTask {
+
+    default boolean cancel() {
+        return false;
+    }
+
+    void registerScheduler(MoeScheduler scheduler);
+}

--- a/src/main/java/moe/maple/scheduler/tasks/delay/MoeDelayedTask.java
+++ b/src/main/java/moe/maple/scheduler/tasks/delay/MoeDelayedTask.java
@@ -22,14 +22,17 @@
 
 package moe.maple.scheduler.tasks.delay;
 
+import moe.maple.scheduler.MoeScheduler;
+import moe.maple.scheduler.tasks.MoeFutureTask;
 import moe.maple.scheduler.tasks.MoeTask;
 
-public class MoeDelayedTask implements MoeTask {
+public class MoeDelayedTask implements MoeFutureTask {
 
     private final MoeTask actual;
     private final long start, delay;
 
     private boolean hasRun;
+    private MoeScheduler scheduler;
 
     public MoeDelayedTask(MoeTask actual, long delay, long start) {
         if (actual == null)
@@ -41,6 +44,19 @@ public class MoeDelayedTask implements MoeTask {
 
     public MoeDelayedTask(MoeTask actual, long delay) {
         this(actual, delay, System.currentTimeMillis());
+    }
+
+    @Override
+    public void registerScheduler(MoeScheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    public boolean cancel() {
+        if(scheduler != null) {
+            return scheduler.unregister(this);
+        }
+        return false;
     }
 
     @Override
@@ -61,3 +77,4 @@ public class MoeDelayedTask implements MoeTask {
         }
     }
 }
+

--- a/src/main/java/moe/maple/scheduler/tasks/delay/MoeRepeatingDelayedTask.java
+++ b/src/main/java/moe/maple/scheduler/tasks/delay/MoeRepeatingDelayedTask.java
@@ -22,14 +22,17 @@
 
 package moe.maple.scheduler.tasks.delay;
 
+import moe.maple.scheduler.MoeScheduler;
+import moe.maple.scheduler.tasks.MoeFutureTask;
 import moe.maple.scheduler.tasks.MoeHardTask;
-import moe.maple.scheduler.tasks.MoeTask;
 
-public class MoeRepeatingDelayedTask implements MoeTask {
+public class MoeRepeatingDelayedTask implements MoeFutureTask {
 
     private final MoeHardTask actual;
     private final long delay;
     private long start;
+
+    private MoeScheduler scheduler;
 
     public MoeRepeatingDelayedTask(MoeHardTask actual, long delay, long start) {
         if (actual == null)
@@ -41,6 +44,19 @@ public class MoeRepeatingDelayedTask implements MoeTask {
 
     public MoeRepeatingDelayedTask(MoeHardTask actual, long delay) {
         this(actual, delay, System.currentTimeMillis());
+    }
+
+    @Override
+    public void registerScheduler(MoeScheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    public boolean cancel() {
+        if(scheduler != null) {
+            return scheduler.unregister(this);
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Typically, when you want to create a timed-task and cancel it, you had to physically find the task, a scheduler that has been used, and invoke either `unregister(MoeTask task)` or `remove(Predicate<MoeTask> check)` from `MoeScheduler.java`. While this is a perfectly valid way to cancel the task, it is often tedious and prone to errors, particularly when you are using multiple schedulers. To combat this, I have created a new interface `MoeFutureTask` that inherits from `MoeTask` that allows for timed-tasks to be cancelled by simply invoking `cancel()` method. This way, one do not need to search for scheduler that has been registered on. Additionally, invoking `registerDelayed` method from `MoeScheduler.java` now returns `MoeFutureTask` that can be used to be stored as a variable and cancelled whenever desired.

Example usage:
Before
```java
var task = new MoeDelayedTask((delta) -> doSomething(), 10000);
scheduler.register(task);
//After some time....
scheduler.unregister(task);
```
After
```java
var task = scheduler.registerDelayed((delta) -> doSomething(), 10000);
//After some time...
task.cancel() //Returns true if successful
```
